### PR TITLE
refactor: run scripts with bash

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ COPY ./solvers /solvers
 COPY ./utils /utils
 
 # Fix permissions
-RUN find . -type f -iname "*.sh" -exec chmod +x {} \;
+RUN find /utils -type f -iname "*.sh" -exec chmod +x {} +
 
 # Install CPLEX
 RUN /utils/install_cplex.sh


### PR DESCRIPTION
Rather than fixing up permissions (which still failed for me) just run your scripts directly through bash (this should fix #5). With these changes at least the docker image builds. However, I cannot run the resulting image due to yet another permission problem.

```
Obtaining file:///src/pytfa                                                                  
    Complete output from command python setup.py egg_info:                 
    running egg_info                              
    creating pytfa.egg-info                                                                   
    /usr/local/lib/python3.5/site-packages/setuptools/dist.py:351: UserWarning: Normalizing '0
.6.1-b2' to '0.6.1b2'                                                                         
      normalized_version,                                                                    
    error: could not create 'pytfa.egg-info': Permission denied                               
                                                                                              
    ----------------------------------------                                                  
Command "python setup.py egg_info" failed with error code 1 in /src/pytfa/
```

Some thoughts:
1. I appreciate that you do not want to run everything as root in the docker environment but I'm wondering whether that is creating these issues and if it is worth the trouble?
2. The entrypoint in the `Dockerfile` `ENTRYPOINT ["/bin/bash", "-c", "pip install --user -e /src/pytfa && $0 $*"]` is quite hacky. I doubt many people would really want a version of their local code in the docker image. IMO pytfa should be installed from PyPI inside the docker image. For those people who want to play with their local code that way you could simply make that part of the command rather than the entrypoint. So maybe adjust the `run` script accordingly.