### PR TITLE
fix: use host user UID and GID

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,10 +14,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		less			\
     && rm -rf /var/lib/apt/lists/*
 
+ARG UID=1000
+ARG GID=1000
 ENV USER pytfa
 ENV HOME /home/$USER
 
-RUN useradd -ms "/bin/bash" "$USER"
+RUN groupadd -g "${GID}" "$USER" && useradd -u "${UID}" -g "$USER" -ms "/bin/bash" "$USER"
 USER $USER
 WORKDIR $HOME
 

--- a/docker/build
+++ b/docker/build
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker build -t pytfa_docker .
+docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -t pytfa_docker .

--- a/docker/run
+++ b/docker/run
@@ -1,5 +1,5 @@
 #!/bin/sh
-docker run 	--rm -it 			\
+docker run 	--rm -it		\
 		-v $(pwd)/work:/home/pytfa/work \
 		-v $(pwd)/..:/src/pytfa	\
 		pytfa_docker


### PR DESCRIPTION
Avoid permission errors for mounted volumes and also for files created in the container back on
the host.

fix #9 