### PR TITLE
Allow saving of imported mat files as json

### DIFF
--- a/pytfa/io/base.py
+++ b/pytfa/io/base.py
@@ -189,8 +189,7 @@ def import_matlab_model(path, variable_name=None):
         comp = comps[i]
         comp['membranePot'] = {}
         for j in range(num_comp):
-            comp['membranePot'][comps[j]['symbol']] = \
-            CompartmentDB['membranePot'][0][i, j]
+            comp['membranePot'][comps[j]['symbol']] = int(CompartmentDB['membranePot'][0][i, j])
 
     cobra_model.compartments = Compartments
 

--- a/pytfa/io/base.py
+++ b/pytfa/io/base.py
@@ -189,7 +189,7 @@ def import_matlab_model(path, variable_name=None):
         comp = comps[i]
         comp['membranePot'] = {}
         for j in range(num_comp):
-            comp['membranePot'][comps[j]['symbol']] = int(CompartmentDB['membranePot'][0][i, j])
+            comp['membranePot'][comps[j]['symbol']] = float(CompartmentDB['membranePot'][0][i, j])
 
     cobra_model.compartments = Compartments
 


### PR DESCRIPTION
When importing .mat models, the membranePot type is numpy's int16. The change makes it a standard int so that it can be saved as json.