### PR TITLE
ENH: allow different annotation keys

### DIFF
--- a/pytfa/core/model.py
+++ b/pytfa/core/model.py
@@ -121,7 +121,7 @@ class LCSBModel(ABC):
                    **kwargs)
 
         self._var_dict[var.name] = var
-        self.logger.debug('Added variable: {}'.format(var.name))
+        # self.logger.debug('Added variable: {}'.format(var.name))
         # self.add_cons_vars(var.variable)
 
         return var
@@ -151,7 +151,7 @@ class LCSBModel(ABC):
                     queue=queue,
                     **kwargs)
         self._cons_dict[cons.name] = cons
-        self.logger.debug('Added constraint: {}'.format(cons.name))
+        # self.logger.debug('Added constraint: {}'.format(cons.name))
         # self.add_cons_vars(cons.constraint)
 
         return cons

--- a/pytfa/redgem/lumpgem.py
+++ b/pytfa/redgem/lumpgem.py
@@ -103,7 +103,7 @@ class LumpGEM:
             elif is_exchange(rxn):
                 self._exchanges.append(rxn)
             # If it is a transport reaction
-            elif check_transport_reaction(rxn):
+            elif check_transport_reaction(rxn, tfa_model.annotation_key):
                 self._transports.append(rxn)
             # If it's a core reaction
             elif rxn.subsystem in self.core_subsystems:

--- a/pytfa/thermo/metabolite.py
+++ b/pytfa/thermo/metabolite.py
@@ -16,8 +16,7 @@ from math import log, sqrt
 
 from . import std
 from ..utils.numerics import BIGM_THERMO
-
-CPD_PROTON = 'cpd00067'
+from .utils import PROTON
 
 DEFAULT_VAL = BIGM_THERMO
 
@@ -212,7 +211,7 @@ class MetaboliteThermo:
             print("Computing DGis...")
 
         # Special case for protons...
-        if self.id == CPD_PROTON:
+        if self.id in PROTON:
             if self.debug:
                 print("Found proton")
             return -self.RT * log(10 ** -self.pH)
@@ -363,7 +362,7 @@ class MetaboliteThermo:
             print('Computing DGspA()...')
 
         # Case of the proton
-        if self.id == CPD_PROTON:
+        if self.id in PROTON:
             if self.debug:
                 print('Proton found, returning standard values')
             # we do not adjust for proton so just return the values

--- a/pytfa/thermo/tmodel.py
+++ b/pytfa/thermo/tmodel.py
@@ -27,6 +27,7 @@ from .utils import (
     check_transport_reaction,
     find_transported_mets,
     get_reaction_compartment,
+    PROTON
 )
 from ..optim.constraints import (
     SimultaneousUse,
@@ -69,7 +70,8 @@ class ThermoModel(LCSBModel, Model):
     def __init__(self, thermo_data=None, model=Model(), name=None,
                  temperature=std.TEMPERATURE_0,
                  min_ph=std.MIN_PH,
-                 max_ph=std.MAX_PH):
+                 max_ph=std.MAX_PH,
+                 annotation_key="seed_id"):
 
         """
         :param float temperature: the temperature (K) at which to perform the calculations
@@ -84,6 +86,7 @@ class ThermoModel(LCSBModel, Model):
         self.TEMPERATURE = temperature
         self.thermo_data = thermo_data
         self.parent = model
+        self.annotation_key = annotation_key
 
         # CONSTANTS
         self.MAX_pH = max_ph
@@ -150,21 +153,23 @@ class ThermoModel(LCSBModel, Model):
         CompartmentionicStr = self.compartments[met.compartment]["ionicStr"]
 
         # Which index of the reaction DB do you correspond to ?
-        if not "seed_id" in met.annotation:
+        if not self.annotation_key in met.annotation:
             # raise Exception("seed_id missing for " + met.name)
             self.logger.debug(
-                "Metabolite {} ({}) has no seed_id".format(met.id, met.name)
+                "Metabolite {} ({}) has no {}".format(
+                    met.id, met.name, self.annotation_key
+                )
             )
             metData = None
-        elif not met.annotation["seed_id"] in self.compounds_data:
+        elif not met.annotation[self.annotation_key] in self.compounds_data:
             self.logger.debug(
                 "Metabolite {} ({}) not present in thermoDB".format(
-                    met.annotation["seed_id"], met.name
+                    met.annotation[self.annotation_key], met.name
                 )
             )
             metData = None
         else:
-            metData = self.compounds_data[met.annotation["seed_id"]]
+            metData = self.compounds_data[met.annotation[self.annotation_key]]
             # Override the formula
             met.formula = metData["formula"]
 
@@ -216,7 +221,10 @@ class ThermoModel(LCSBModel, Model):
         )
 
         # Also test if this is a transport reaction
-        reaction.thermo["isTrans"] = check_transport_reaction(reaction)
+        reaction.thermo["isTrans"] = check_transport_reaction(
+            reaction,
+            self.annotation_key
+        )
         # Make sure we have correct thermo values for each metabolites
         correctThermoValues = True
 
@@ -240,14 +248,17 @@ class ThermoModel(LCSBModel, Model):
             reaction.thermo["deltaGRerr"] = BIGM_DG
 
         else:
-            self.logger.debug(
-                "{} : thermo constraint created".format(reaction.id)
-            )
+            # self.logger.debug(
+            #     "{} : thermo constraint created".format(reaction.id)
+            # )
             reaction.thermo["computed"] = True
 
             if reaction.thermo["isTrans"]:
                 (rhs, breakdown) = calcDGtpt_rhs(
-                    reaction, self.compartments, self.thermo_unit
+                    reaction,
+                    self.compartments,
+                    self.thermo_unit,
+                    self.annotation_key
                 )
 
                 reaction.thermo["deltaGR"] = rhs
@@ -256,9 +267,9 @@ class ThermoModel(LCSBModel, Model):
             else:
                 for met in reaction.metabolites:
                     if met.formula != "H" or (
-                        "seed_id" in met.annotation
+                        self.annotation_key in met.annotation
                         # That's H+
-                        and met.annotation["seed_id"] != "cpd00067"
+                        and met.annotation[self.annotation_key] != "cpd00067"
                     ):
                         DeltaGrxn += (
                             reaction.metabolites[met] * met.thermo.deltaGf_tr
@@ -311,8 +322,8 @@ class ThermoModel(LCSBModel, Model):
         proton = {}
         for i in range(num_mets):
             if self.metabolites[i].formula == "H" or (
-                "seed_id" in self.metabolites[i].annotation
-                and self.metabolites[i].annotation["seed_id"] == "cpd00067"
+                self.annotation_key in self.metabolites[i].annotation
+                and self.metabolites[i].annotation[self.annotation_key] in PROTON
             ):
                 proton[self.metabolites[i].compartment] = self.metabolites[i]
 
@@ -363,8 +374,8 @@ class ThermoModel(LCSBModel, Model):
             )
 
         elif (
-            "seed_id" in met.annotation
-            and met.annotation["seed_id"] == "cpd11416"
+            self.annotation_key in met.annotation
+            and met.annotation[self.annotation_key] == "cpd11416"
         ):
             # we do not create the thermo variables for biomass enzyme
             pass
@@ -421,7 +432,7 @@ class ThermoModel(LCSBModel, Model):
         H2OtRxns = False
         if rxn.thermo["isTrans"] and len(rxn.reactants) == 1:
             try:
-                if rxn.reactants[0].annotation["seed_id"] == "cpd00001":
+                if rxn.reactants[0].annotation[self.annotation_key] == "cpd00001":
                     H2OtRxns = True
             except KeyError:
                 pass
@@ -460,7 +471,7 @@ class ThermoModel(LCSBModel, Model):
                 # enzyme. This will be added to the constraint on the Right
                 # Hand Side (RHS)
 
-                transportedMets = find_transported_mets(rxn)
+                transportedMets = find_transported_mets(rxn, self.annotation_key)
 
                 # Chemical coefficient, it is the enzyme's coefficient...
                 # + transport coeff for reactants
@@ -560,10 +571,11 @@ class ThermoModel(LCSBModel, Model):
 
         else:
             if not NotDrain:
-                self.logger.debug(
-                    "generating only use constraints for drain reaction"
-                    + rxn.id
-                )
+                # self.logger.debug(
+                #     "generating only use constraints for drain reaction"
+                #     + rxn.id
+                # )
+                pass
             else:
                 self.logger.debug(
                     "generating only use constraints for reaction" + rxn.id
@@ -630,7 +642,7 @@ class ThermoModel(LCSBModel, Model):
             for reaction in self.reactions:
                 if not "isTrans" in reaction.thermo:
                     reaction.thermo["isTrans"] = check_transport_reaction(
-                        reaction
+                        reaction, self.annotation_key
                     )
         except:
             raise Exception(

--- a/pytfa/thermo/utils.py
+++ b/pytfa/thermo/utils.py
@@ -13,6 +13,34 @@ import re
 
 Formula_regex = re.compile("([A-Z][a-z]*)([0-9]*)")
 
+# idenfifiers of water metabolite in different databases
+PROTON = {
+    "h",  "15378", "10744", "13357", "5584", "24636", "29233", "29234",
+    "MNXM104313", "MNXM113751", "MNXM145872", "MNXM89553", "HMDB59597",
+    "C00080", "PROTON", "1132304", "113529", "1470067", "156540", "163953",
+    "193465", "194688", "2000349", "2872447", "351626", "372511", "374900",
+    "425969", "425978", "425999", "427899", "428040", "428548", "5668577",
+    "70106", "74722",  "39",  "cpd00067",  "MNXM1"
+}
+
+# idenfifiers of water metabolite in different databases
+WATER = {
+    "h2o", "oh1", "15377", "10743", "13352", "27313", "42043", "42857",
+    "43228", "44292", "44701", "44819", "5585", "16234", "13365", "13419",
+    "44641", "5594", "29356", "29374", "29375", "29412", "30490", "33806",
+    "33811", "33813", "41981", "29373", "41979", "MNXM114710", "MNXM114753",
+    "MNXM11838", "MNXM124004", "MNXM124324", "MNXM124831", "MNXM125045",
+    "MNXM126600", "MNXM128935", "MNXM131091", "MNXM145357", "MNXM49218",
+    "MNXM56889", "MNXM89551", "5882df9c-dae1-4d80-a40e-db4724271456\/compound\/969d0227-3069-4e44-9525-7ae7bad84170",
+    "650babc9-9d68-4b73-9332-11972ca26f7b\/compound\/799908db-b8c9-4982-86cb-1f225e2ad08c",
+    "650babc9-9d68-4b73-9332-11972ca26f7b\/compound\/e7f34a8e-cded-4793-b6d5-792335b38636",
+    "HMDB02111", "C00001", "D00001", "C01328", "C18714", "D03703", "D06322",
+    "CPD-15815", "HYDROXYL-GROUP", "OH", "OXONIUM", "WATER", "109276",
+    "1130930", "113518", "113519", "113521", "141343", "1605715", "189422",
+    "2022884", "29356", "351603", "5278291", "5668574", "5693747", "8851517",
+    "40", "cpd00001", "cpd15275", "cpd27222", "MNXM2"
+}
+
 
 def check_reaction_balance(reaction, proton = None):
     """
@@ -105,7 +133,7 @@ def check_reaction_balance(reaction, proton = None):
     return 'missing atoms'
 
 
-def find_transported_mets(reaction):
+def find_transported_mets(reaction, annotation_key="seed_id"):
     """
     Get a list of the transported metabolites of the reaction.
 
@@ -135,7 +163,7 @@ def find_transported_mets(reaction):
     reactants_coeffs = {}
 
     for met in reaction.reactants:
-        reactants_coeffs[met.annotation['seed_id']] = {
+        reactants_coeffs[met.annotation[annotation_key]] = {
             'coeff':reaction.metabolites[met],
             'met':met
         }
@@ -144,7 +172,7 @@ def find_transported_mets(reaction):
     trans_coeffs = {}
 
     for met in reaction.products:
-        seed_id = met.annotation['seed_id']
+        seed_id = met.annotation[annotation_key]
 
         # If the seed_id also corresponds to a reactant, we add it to the result
         if seed_id in reactants_coeffs:
@@ -160,7 +188,7 @@ def find_transported_mets(reaction):
     return trans_coeffs
 
 
-def check_transport_reaction(reaction):
+def check_transport_reaction(reaction, annotation_key="seed_id"):
     """
 
     Check if a reaction is a transport reaction
@@ -179,10 +207,10 @@ def check_transport_reaction(reaction):
     seed_ids = {}
     try:
         for reactant in reaction.reactants:
-            seed_ids[reactant.annotation['seed_id']] = True
+            seed_ids[reactant.annotation[annotation_key]] = True
 
         for product in reaction.products:
-            if product.annotation['seed_id'] in seed_ids:
+            if product.annotation[annotation_key] in seed_ids:
                 return True
     except KeyError:
         reactants_ids = [x.id.replace(x.compartment,'') for x in reaction.reactants]


### PR DESCRIPTION
### Description
Changing the annotation of the metabolites on the fly works but it is not scalable and hinders the use of alternative thermodynamic databases with other DB identifiers. Furthermore, it is usually the case that GEMs come with SEED annotations but with a different key, such as "seed.compound", "seed.id", etc. instead of `seed_id`, so it would be useful to allow the user to define which annotation key (as in `cobra.Metabolite.annotation[key]`) should be matched against the database during the preparation/conversion of the `ThermoModel`.
 
### Implementation
* The `__init__()` method of [`pytfa.thermo.ThermoModel`](https://github.com/EPFL-LCSB/pytfa/blob/master/pytfa/thermo/tmodel.py#L63) now accepts an additional argument `annotation_key` used during preparation/conversion, which defaults to `seed_id`.
* This additional argument was propagated to the relevant utility functions used on _prepare and _convert.
* PROTON and WATER identifiers from different DBs were added instead of only the SEED variants.
* A test was added to the test suite.